### PR TITLE
Bugfix: Add symlink to readme in place Github expects it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+src/lexmachina_README.md


### PR DESCRIPTION
@psevenants pointed out there is no readme shown when someone visits the repo on github.